### PR TITLE
Update xpp-statements-loops.md for accuracy 

### DIFF
--- a/articles/fin-ops-core/dev-itpro/dev-ref/xpp-statements-loops.md
+++ b/articles/fin-ops-core/dev-itpro/dev-ref/xpp-statements-loops.md
@@ -101,9 +101,9 @@ public boolean isLate()
 }
 ```
 
-## <a name="unsupported-statements-changesite-pause-and-window"></a>構文はサポートされていません: changeSite、一時停止、およびウィンドウ
+## <a name="unsupported-statements-pause-and-window"></a>構文はサポートされていません:「一時停止」と「およびウィンドウ」
 
-**changeSite**、**pause**、**window** キーワードは、X++ 言語の一部ではなくなりました。 これらのキーワードを使用すると、コンパイル エラーが発生します。
+**pause**　と　**window** キーワードは、X++ 言語の一部ではなくなりました。 これらのキーワードを使用すると、コンパイル エラーが発生します。
 
 ## <a name="ignored-statements-server-and-client"></a>無視されたステートメント: サーバーおよびクライアント
 

--- a/articles/fin-ops-core/dev-itpro/dev-ref/xpp-statements-loops.md
+++ b/articles/fin-ops-core/dev-itpro/dev-ref/xpp-statements-loops.md
@@ -101,7 +101,7 @@ public boolean isLate()
 }
 ```
 
-## <a name="unsupported-statements-pause-and-window"></a>構文はサポートされていません:「一時停止」と「およびウィンドウ」
+## <a name="unsupported-statements-pause-and-window"></a>構文はサポートされていません:「pause」と「window」
 
 **pause**　と　**window** キーワードは、X++ 言語の一部ではなくなりました。 これらのキーワードを使用すると、コンパイル エラーが発生します。
 


### PR DESCRIPTION
Today, I made [PR #5006 in MicrosoftDocs/dynamics-365-unified-operations-public](https://github.com/MicrosoftDocs/dynamics-365-unified-operations-public/pull/5006), which removed references to a "changeSite" keyword that seemingly never existed. Its message is duplicated below for convenience. 

This PR makes changes to the same effect. It also un-translates the "pause" keyword (which was listed as 一時停止) and the "window" keyword (which was listed as およびウィンドウ), as "pause" and "window" were reserved, but 「一時停止」 and 「およびウィンドウ」were not. 

----- MicrosoftDocs/dynamics-365-unified-operations-public#5006 - message begins -----
In researching the history of Dynamics 365 and X++, I came across this site suggesting that there used to be a keyword "changeSite" in the X++ language.

The blog [AXForce](https://axforce.wordpress.com/tag/x/) suggests that "pause", "window" and "changeSite" were all removed as of AX 7 (2016). This is the only other reference to the changeSite keyword I was able to find online. Nowhere explains the specific functionality of the keyword.

In reply to [my post on the Microsoft Dynamics AX Forum](https://community.dynamics.com/forums/thread/details/?threadid=dfb68320-7f90-ef11-ac21-6045bdd3c2dc), SWE Jonas "Jones" Melgaard, who has over 12 years of experience working with Axapta/AX/D365, notes that he does not recall having used the keyword and verifies that it was not a reserved word as of AX 2012 R3, discounting the credibility of the post on AXForce.

Furthermore, in reply to [a question I asked on Stack Overflow](https://stackoverflow.com/a/79115166/22412782), user 10p verified that there were no references to a "changeSite" keyword in the books Inside Microsoft Dynamics® AX 2009 (pub. 2009, ISBN 9780735626454) or Inside Microsoft Dynamics AX 4.0 (pub. 2006, ISBN 9780735622579).

Also having spoken to some colleagues, many of whom have near 2 decades experience in X++, they do not recall the presence of a changeSite keyword in X++ at any point in time.

The concensus among all involved in this discussion is that this is a mistake in the documentation, and that changeSite never existed. As such, I'm proposing that it be removed from this page so as to avoid future confusion and misinformation.

I also intend to create a PR in [MicrosoftDocs/Dynamics-365-Operations.ja-jp](https://github.com/MicrosoftDocs/Dynamics-365-Operations.ja-jp/blob/live/articles/fin-ops-core/dev-itpro/dev-ref/xpp-statements-loops.md) shortly to mirror the effect of this one.
----- MicrosoftDocs/dynamics-365-unified-operations-public#5006 - message ends -----